### PR TITLE
FIX:  Removing ConditionType from Terraform State generation as it breaks existing AlertConditions when Controller is restarted

### DIFF
--- a/config/external_name.go
+++ b/config/external_name.go
@@ -96,7 +96,7 @@ func configAlertPolicy() config.ExternalName {
 }
 
 // See - https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/nrql_alert_condition#import
-// NRQL alert conditions can be imported using a composite ID of <policy_id>:<condition_id>:<conditionType>, e.g.
+// NRQL alert conditions can be imported using a composite ID of <policy_id>:<condition_id>, e.g.
 func configNrqAlertCondition() config.ExternalName {
 	e := config.IdentifierFromProvider
 
@@ -110,13 +110,13 @@ func configNrqAlertCondition() config.ExternalName {
 		if !ok {
 			return "", errors.New("Can't format id from tfstate as string")
 		}
-		// <policy_id>:<condition_id>:<conditionType>
+		// <policy_id>:<condition_id>
 		words := strings.Split(idStr, ":")
 		return words[1], nil
 	}
 
 	// See - https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/nrql_alert_condition#import
-	// Formats the condition id as <policy_id>:<condition_id>:<conditionType>
+	// Formats the condition id as <policy_id>:<condition_id>
 	e.GetIDFn = func(_ context.Context, externalName string, parameters map[string]interface{}, _ map[string]interface{}) (string, error) {
 		// Using a stub value to pass validation.
 		if len(externalName) == 0 {
@@ -129,18 +129,8 @@ func configNrqAlertCondition() config.ExternalName {
 		}
 		policyIDStr := strconv.FormatFloat(policyID.(float64), 'f', 0, 64)
 
-		conditionType, ok := parameters["type"]
-		if !ok {
-			return "", errors.New("Can't get type from nrql alert condition")
-		}
-
-		conditionTypeStr, ok := conditionType.(string)
-		if !ok {
-			return "", errors.New("Can't format type as string for nrql alert condition")
-		}
-
-		// <policy_id>:<condition_id>:<conditionType>
-		return fmt.Sprintf("%s:%s:%s", policyIDStr, externalName, conditionTypeStr), nil
+		// <policy_id>:<condition_id>
+		return fmt.Sprintf("%s:%s", policyIDStr, externalName), nil
 	}
 	return e
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Removing conditionType from Terraform State generation as it breaks existing Alert Conditions causing them to fail to Reconcile after the controller Pod is restarted

Fixes #22

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- Validated differences between State of new and existing Alert Condition
- Confirmed  conditonType was added in error

[contribution process]: https://git.io/fj2m9
