### PR TITLE
fix: register schemas in runtime (critical regression bug)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ cover.out
 # ignore IDE folders
 .vscode/
 .idea/
+provider

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/statemetrics"
 	tjcontroller "github.com/crossplane/upjet/v2/pkg/controller"
 	"github.com/crossplane/upjet/v2/pkg/terraform"
+	"github.com/go-logr/logr"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	authv1 "k8s.io/api/authorization/v1"
@@ -41,6 +42,7 @@ import (
 	apisCluster "github.com/crossplane-contrib/crossplane-provider-newrelic/apis/cluster"
 	apisNamespaced "github.com/crossplane-contrib/crossplane-provider-newrelic/apis/namespaced"
 	config "github.com/crossplane-contrib/crossplane-provider-newrelic/config"
+	resolverapis "github.com/crossplane-contrib/crossplane-provider-newrelic/internal/apis"
 	"github.com/crossplane-contrib/crossplane-provider-newrelic/internal/clients"
 	controllerCluster "github.com/crossplane-contrib/crossplane-provider-newrelic/internal/controller/cluster"
 	controllerNamespaced "github.com/crossplane-contrib/crossplane-provider-newrelic/internal/controller/namespaced"
@@ -94,6 +96,10 @@ func main() {
 		// *very* verbose even at info level, so we only provide it a real
 		// logger when we're running in debug mode.
 		ctrl.SetLogger(zl)
+	} else {
+		// Explicitly set a discard logger so controller-runtime does not
+		// complain that log.SetLogger(...) was never called.
+		ctrl.SetLogger(logr.Discard())
 	}
 
 	log.Debug("Starting", "sync-period", syncPeriod.String(), "poll-interval", pollInterval.String(), "max-reconcile-rate", *maxReconcileRate)
@@ -152,6 +158,8 @@ func main() {
 	kingpin.FatalIfError(apisNamespaced.AddToScheme(mgr.GetScheme()), "Cannot add namespaced NewRelic APIs to scheme")
 	kingpin.FatalIfError(apiextensionsv1.AddToScheme(mgr.GetScheme()), "Cannot add api-extensions APIs to scheme")
 	kingpin.FatalIfError(authv1.AddToScheme(mgr.GetScheme()), "Cannot add k8s authorization APIs to scheme")
+	kingpin.FatalIfError(resolverapis.BuildScheme(apisCluster.AddToSchemes), "Cannot register the cluster-scoped NewRelic APIs with the API resolver's runtime scheme")
+	kingpin.FatalIfError(resolverapis.BuildScheme(apisNamespaced.AddToSchemes), "Cannot register the namespaced NewRelic APIs with the API resolver's runtime scheme")
 
 	clusterOpts := tjcontroller.Options{
 		Options: xpcontroller.Options{

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/crossplane/crossplane-runtime/v2 v2.2.0
 	github.com/crossplane/crossplane-tools v0.0.0-20250731192036-00d407d8b7ec
 	github.com/crossplane/upjet/v2 v2.2.1-0.20260507165441-14501756888d
+	github.com/go-logr/logr v1.4.3
 	github.com/pkg/errors v0.9.1
 	google.golang.org/grpc v1.81.1
 	k8s.io/api v0.35.3
@@ -36,7 +37,6 @@ require (
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.22.4 // indirect
 	github.com/go-openapi/jsonreference v0.21.4 // indirect


### PR DESCRIPTION
This is a critical regression bug that breaks reference lookups, without it the provider throws errors such as :
cannot resolve references: failed to get the reference target managed resource and its list for reference resolution: failed to get a new API object of GVK "alert.newrelic.m.upbound.io/v1alpha1, Kind=Policy" from the runtime scheme: no kind "Policy" is registered for version "alert.newrelic.m.upbound.io/v1alpha1" in scheme "pkg/runtime/scheme.go:111"

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

It is deployed in our cluster and works now

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
